### PR TITLE
CI: make sure to test on the latest stable 1.x release of Julia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,7 @@ jobs:
         version:
           - '1.3'
           - '1.5'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest


### PR DESCRIPTION
In GitHub Actions, `'1'` will automatically expand to the latest stable 1.x release of Julia. Therefore, by adding `'1'` to the build matrix, CI will always be run on the latest Julia 1.x. This can potentially reduce the number of times that the CI workflow file needs to be edited.