### PR TITLE
Vendor the fixed `get_server_dir`, but compare its output to that of the upstream `Pkg.PlatformEngines.get_server_dir`, and print a warning if the two values differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Interactive browser-based authentication to private Julia Pkg servers.
 #### Step 1: Make sure that PkgAuthentication.jl is installed in the default global Julia package environment (`v1.x`)
 
 ```julia
-julia> delete!(ENV, "JULIA_PKG_SERVER")
+julia> delete!(ENV, "JULIA_PKG_SERVER");
 
 julia> import Pkg
 

--- a/src/PkgAuthentication.jl
+++ b/src/PkgAuthentication.jl
@@ -373,25 +373,9 @@ is_token_valid(toml) =
     (get(toml, "expires_at", nothing) isa Union{Integer, AbstractFloat} ||
      get(toml, "expires", nothing) isa Union{Integer, AbstractFloat})
 
-@static if Base.VERSION >= v"1.10-" # TODO: change this to "1.9-" if we are able to fix Pkg in time for 1.9
-    const get_server_dir = Pkg.PlatformEngines.get_server_dir
-else
-    # This implementation of `get_server_dir` handles `domain:port` servers correctly (fixed on Pkg#master but not in older Julia versions).
-    function get_server_dir(url::AbstractString, server = get_pkg_server())
-        server === nothing && return
-        url == server || startswith(url, "$server/") || return
-        m = match(r"^\w+://(?:[^\\/@]+@)?([^\\/:]+)(?:$|/|:)", server)
-        if m === nothing
-            @warn "malformed Pkg server value" server
-            return
-        end
-        joinpath(Pkg.depots1(), "servers", m.captures[1])
-    end
-end
-
 function token_path(url::AbstractString)
     @static if is_new_auth_mechanism()
-        server_dir = get_server_dir(url)
+        server_dir = Pkg.PlatformEngines.get_server_dir(url)
         if server_dir !== nothing
             return joinpath(server_dir, "auth.toml")
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,33 +6,6 @@ import Pkg
 
 include("util.jl")
 
-@static if Base.VERSION < v"1.4-"
-    @eval Pkg function pkg_server()::Union{String, Nothing}
-        server = get(ENV, "JULIA_PKG_SERVER", "https://pkg.julialang.org")
-        isempty(server) && return nothing
-        startswith(server, r"\w+://") || (server = "https://$server")
-        return rstrip(server, '/')
-    end
-end
-@static if Base.VERSION < v"1.10-" # TODO: change this to "1.9-"
-     @eval Pkg.PlatformEngines function get_server_dir(
-        url :: AbstractString,
-        server :: Union{AbstractString, Nothing} = pkg_server(),
-    )
-        server === nothing && return
-        url == server || startswith(url, "$server/") || return
-        m = match(r"^\w+://([^\\/]+)(?:$|/)", server)
-        if m === nothing
-            @warn "malformed Pkg server value" server
-            return
-        end
-        isempty(Base.DEPOT_PATH) && return
-        invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
-        dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(String(m.captures[1]))))
-        return joinpath(depots1(), "servers", dir)
-    end
- end
-
 @testset "PkgAuthentication" begin
     with_temp_depot() do
         include("tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,33 @@ import Pkg
 
 include("util.jl")
 
+@static if Base.VERSION < v"1.4-"
+    @eval Pkg function pkg_server()::Union{String, Nothing}
+        server = get(ENV, "JULIA_PKG_SERVER", "https://pkg.julialang.org")
+        isempty(server) && return nothing
+        startswith(server, r"\w+://") || (server = "https://$server")
+        return rstrip(server, '/')
+    end
+end
+@static if Base.VERSION < v"1.10-" # TODO: change this to "1.9-"
+     @eval Pkg.PlatformEngines function get_server_dir(
+        url :: AbstractString,
+        server :: Union{AbstractString, Nothing} = pkg_server(),
+    )
+        server === nothing && return
+        url == server || startswith(url, "$server/") || return
+        m = match(r"^\w+://([^\\/]+)(?:$|/)", server)
+        if m === nothing
+            @warn "malformed Pkg server value" server
+            return
+        end
+        isempty(Base.DEPOT_PATH) && return
+        invalid_filename_chars = [':', '/', '<', '>', '"', '/', '\\', '|', '?', '*']
+        dir = join(replace(c -> c in invalid_filename_chars ? '_' : c, collect(String(m.captures[1]))))
+        return joinpath(depots1(), "servers", dir)
+    end
+ end
+
 @testset "PkgAuthentication" begin
     with_temp_depot() do
         include("tests.jl")


### PR DESCRIPTION
Suppose that Pkg and PkgAuthentication have different behaviors for determining the path of the token file (given the same exact `server` as input). So, then, for example, PkgAuthentication might create a token file at e.g. `~/.julia/servers/localhost_1234/auth.toml`. But then when it comes time for Pkg to construct the authentication header, Pkg looks for a token file at `~/.julia/servers/localhost:1234/auth.toml`. And now authentication fails because PkgAuthentication created a token in one location, and Pkg is looking for a token in a second location.

So I think we actually need PkgAuthentication and Pkg to always use the exact same `get_server_dir` function.