### PR TITLE
Check that JULIA_PKG_SERVER is non-empty

### DIFF
--- a/src/PkgAuthentication.jl
+++ b/src/PkgAuthentication.jl
@@ -23,8 +23,8 @@ abstract type Failure <: State end
 ## authentication state machine
 
 function _assert_pkg_server_env_var_is_set()
-    if !haskey(ENV, pkg_server_env_var_name)
-        msg = "The `$(pkg_server_env_var_name)` environment variable must be set"
+    if isempty(strip(get(ENV, pkg_server_env_var_name, "")))
+        msg = "The `$(pkg_server_env_var_name)` environment variable must be set and non-empty"
         throw(ErrorException(msg))
     end
     return nothing

--- a/src/PkgAuthentication.jl
+++ b/src/PkgAuthentication.jl
@@ -23,7 +23,7 @@ abstract type Failure <: State end
 ## authentication state machine
 
 function _assert_pkg_server_env_var_is_set()
-    if isempty(strip(get(ENV, pkg_server_env_var_name, "")))
+    if isempty(get(ENV, pkg_server_env_var_name, ""))
         msg = "The `$(pkg_server_env_var_name)` environment variable must be set and non-empty"
         throw(ErrorException(msg))
     end


### PR DESCRIPTION
Currently, if `JULIA_PKG_SERVER` is set but empty, you get this:

```
JULIA_PKG_SERVER= julia -e 'using PkgAuthentication; PkgAuthentication.authenticate()'
ERROR: MethodError: no method matching rstrip(::Nothing, ::Char)
Closest candidates are:
  rstrip(::Any, ::AbstractString) at strings/util.jl:382
  rstrip(::AbstractString, ::Union{AbstractChar, Tuple{Vararg{AbstractChar}}, Set{<:AbstractChar}, AbstractVector{<:AbstractChar}}) at strings/util.jl:389
Stacktrace:
 [1] authenticate(; auth_suffix::Nothing, force::Nothing, tries::Nothing)
   @ PkgAuthentication ~/.julia/packages/PkgAuthentication/YFLW0/src/PkgAuthentication.jl:103
 [2] authenticate()
   @ PkgAuthentication ~/.julia/packages/PkgAuthentication/YFLW0/src/PkgAuthentication.jl:77
 [3] top-level scope
   @ none:1
```

This is because `Pkg.pkg_server() === nothing` if `JULIA_PKG_SERVER` is set, but empty.

With this you get

```
$ JULIA_PKG_SERVER= julia --project -e 'using PkgAuthentication; PkgAuthentication.authenticate()'
ERROR: The `JULIA_PKG_SERVER` environment variable must be set and non-empty
Stacktrace:
 [1] _assert_pkg_server_env_var_is_set()
   @ PkgAuthentication ~/jc/PkgAuthentication.jl/src/PkgAuthentication.jl:28
 [2] authenticate(; auth_suffix::Nothing, force::Nothing, tries::Nothing)
   @ PkgAuthentication ~/jc/PkgAuthentication.jl/src/PkgAuthentication.jl:100
 [3] authenticate()
   @ PkgAuthentication ~/jc/PkgAuthentication.jl/src/PkgAuthentication.jl:77
 [4] top-level scope
   @ none:1
```

which is a bit more informative.