### PR TITLE
Use TOML standard library explicitly instead of `Pkg.TOML`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/src/PkgAuthentication.jl
+++ b/src/PkgAuthentication.jl
@@ -4,6 +4,7 @@ import Downloads
 import JSON
 import Pkg
 import Random
+import TOML
 
 const pkg_server_env_var_name = "JULIA_PKG_SERVER"
 
@@ -132,7 +133,7 @@ end
 function step(state::NeedAuthentication)::Union{HasToken, NoAuthentication}
     path = token_path(state.server)
     if isfile(path)
-        toml = Pkg.TOML.parsefile(path)
+        toml = TOML.parsefile(path)
         if is_token_valid(toml)
             return HasToken(state.server, mtime(path), toml)
         else
@@ -228,9 +229,9 @@ function step(state::HasNewToken)::Union{HasNewToken, Success, Failure}
     mkpath(dirname(path))
     try
         open(path, "w") do io
-            Pkg.TOML.print(io, state.token)
+            TOML.print(io, state.token)
         end
-        if Pkg.TOML.parsefile(path) == state.token
+        if TOML.parsefile(path) == state.token
             return Success(state.token)
         else
             return HasNewToken(state.server, state.token, 0)


### PR DESCRIPTION
I presume the implementation predates moving `TOML` into a separate standard library.

For a second I was concerned about this not working on < 1.6 (compat is Julia >= 1.3). But it seems like TOML v1 is available as a standard package as well for Julia >= 1.0, so it also works on older Julia versions.