### PR TITLE
fix: use json serialization for robustness

### DIFF
--- a/src/PkgAuthentication.jl
+++ b/src/PkgAuthentication.jl
@@ -339,7 +339,10 @@ function step(state::ClaimToken)::Union{ClaimToken, HasNewToken, Failure}
     sleep(state.poll_interval)
 
     output = IOBuffer()
-    data = """{ "challenge": "$(state.challenge)", "response": "$(state.response)" }"""
+    data = JSON.json(Dict(
+        "challenge" => state.challenge,
+        "response" => state.response,
+    ))
     response = Downloads.request(
         string(state.server, "/claimtoken"),
         method = "POST",


### PR DESCRIPTION
instead of filling in a plain-text template, which could cause issues when challenge or response contain chars that need to be escaped