### PR TITLE
ci: tests against Julia 1.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,7 @@ jobs:
           - '1.7'
           - '1.8'
           - '1.9'
+          - '1.10'
           - '1' # automatically expands to the latest stable 1.x release
           - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,9 @@ jobs:
           # Parts of this package depend on Pkg internals.
           # Because Pkg internals are allowed to change between Julia minor versions,
           # we should run CI on each minor version of Julia that we want to support.
+          # But it's fine to just run these with Linux, as not to make the matrix too
+          # big. Also, Julia 1.4.2 does not work on the macos-latest runner for some
+          # reason, failing with a linking error, so that also sidesteps that issue.
           - '1.3'
           - '1.4'
           - '1.5'
@@ -35,10 +38,23 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
+        # We still want to run CI on Windows and MacOS for some Julia versions, so
+        # so doing that for nightly and the latest release.
+        include:
+          - os: macOS-latest
+            version: '1'
+            arch: x64
+          - os: windows-latest
+            version: '1'
+            arch: x64
+          - os: macOS-latest
+            version: 'nightly'
+            arch: x64
+          - os: windows-latest
+            version: 'nightly'
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,12 +40,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -58,6 +58,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info


### PR DESCRIPTION
This is currently excluded from the matrix. Also update the GitHub Actions versions in the workflow, and add dependabot.