### PR TITLE
Add very basic precompilation

### DIFF
--- a/src/PkgAuthentication.jl
+++ b/src/PkgAuthentication.jl
@@ -621,4 +621,6 @@ function generate_auth_handler(maxcount::Integer)
     return auth_handler
 end
 
+include("precompile.jl")
+
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,2 @@
+precompile(authenticate, ())
+precompile(authenticate, (String,))


### PR DESCRIPTION
Shaves about 50% off the basic `PkgAuthentication.authenticate("example.com")` call (1.1s -> 0.5s on my setup) if you already have the token. Before:

```
BenchmarkTools.Trial: 5 samples with 1 evaluation per sample.
 Range (min … max):  1.133 s …   1.172 s  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.155 s              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.153 s ± 14.355 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                █             █     █                  █
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  1.13 s         Histogram: frequency by time        1.17 s <

 Memory estimate: 1.33 KiB, allocs estimate: 46.
```

After:

```
BenchmarkTools.Trial: 10 samples with 1 evaluation per sample.
 Range (min … max):  516.547 ms … 546.332 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     530.276 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   531.262 ms ±  12.163 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁▁    ▁    ▁          ▁          ▁                ▁   ▁     █  
  ██▁▁▁▁█▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█▁▁▁▁▁█ ▁
  517 ms           Histogram: frequency by time          546 ms <

 Memory estimate: 1.33 KiB, allocs estimate: 46.
```

I didn't really check the interactive case, but I don't think it's _that_ important, since it will prompt for user input anyway.