### PR TITLE
fix: fetch token scope from discovery endpoint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgAuthentication"
 uuid = "4722fa14-9d28-45f9-a1e2-a38605bd88f0"
 authors = ["Sebastian Pfitzner", "contributors"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/docs/auth-flows.md
+++ b/docs/auth-flows.md
@@ -106,16 +106,31 @@ When device authentication is not supported by the server the response body MAY 
 }
 ```
 
+If the `auth_flows` property is present, it MUST be an array of strings.
+If it is missing, it is assumed to have the value `["classic"]`.
+
 In this case, PkgAuthentication will execute the Classic Authentication Flow.
 
-When device authentication _is_ supported by the server, the response body MUST contain:
+When device authentication _is_ supported by the server, the response body MUST contain the `auth_flows` property, and the array MUST contain the value `device`.
+Additionally, the response body MUST contain the following properties:
+
+- `device_authorization_endpoint`: URL to be used to initiate the device authentication flow.
+- `device_token_endpoint`: URL to be used to exchange the device code for a token.
+- `device_token_refresh_url`: URL that can be used to refresh the token.
+
+Furthermore, the response body MAY contain the following properties:
+
+- `device_token_scope`: Scope to be used when requesting a token. If missing, the scope will be omitted from the device token request.
+
+An example of a possible valid response body:
 
 ```json
 {
   "auth_flows": ["classic", "device"],
   "device_token_refresh_url": "https://juliahub.com/auth/renew/token.toml/device/",
   "device_authorization_endpoint": "https://auth.juliahub.com/auth/device/code",
-  "device_token_endpoint": "https://auth.juliahub.com/auth/token"
+  "device_token_endpoint": "https://auth.juliahub.com/auth/token",
+  "device_token_scope": "openid email profile offline_access"
 }
 ```
 

--- a/docs/auth-flows.md
+++ b/docs/auth-flows.md
@@ -127,9 +127,9 @@ An example of a possible valid response body:
 ```json
 {
   "auth_flows": ["classic", "device"],
-  "device_token_refresh_url": "https://juliahub.com/auth/renew/token.toml/device/",
   "device_authorization_endpoint": "https://auth.juliahub.com/auth/device/code",
   "device_token_endpoint": "https://auth.juliahub.com/auth/token",
+  "device_token_refresh_url": "https://juliahub.com/auth/renew/token.toml/device/",
   "device_token_scope": "openid email profile offline_access"
 }
 ```

--- a/test/authserver.jl
+++ b/test/authserver.jl
@@ -4,12 +4,11 @@ import Pkg: TOML
 const EXPIRY = 30
 const CHALLENGE_EXPIRY = 10
 const PORT = 8888
-const LEGACY_MODE = 1
-const DEVICE_FLOW_MODE = 2
+@enum AuthFlowMode CLASSIC_MODE DEVICE_FLOW_MODE DEVICE_FLOW_NO_SCOPE_MODE
 
 const ID_TOKEN = Random.randstring(100)
 const TOKEN = Ref(Dict())
-const MODE = Ref(LEGACY_MODE)
+const MODE = Ref(CLASSIC_MODE)
 
 challenge_response_map = Dict()
 challenge_timeout = Dict()
@@ -102,29 +101,40 @@ function check_validity(req)
     return HTTP.Response(200, payload == TOKEN[])
 end
 
-function set_mode_legacy(req)
-    MODE[] = LEGACY_MODE
-    return HTTP.Response(200)
-end
-
-function set_mode_device(req)
-    MODE[] = DEVICE_FLOW_MODE
+function set_mode(req)
+    global MODE
+    mode = get(HTTP.getparams(req), "mode", nothing)
+    if mode == "classic"
+        MODE[] = CLASSIC_MODE
+    elseif mode == "device"
+        MODE[] = DEVICE_FLOW_MODE
+    elseif mode == "device-no-scope"
+        MODE[] = DEVICE_FLOW_NO_SCOPE_MODE
+    else
+        return HTTP.Response(400, "Invalid Mode $(mode)")
+    end
     return HTTP.Response(200)
 end
 
 function auth_configuration(req)
-    if MODE[] == LEGACY_MODE
-        return HTTP.Response(200)
+    global MODE
+    if MODE[] == CLASSIC_MODE
+        # classic mode could also return `auth_flows = ["classic"]`, but we choose to test
+        # the legacy case where the configuration is not implemented at all (which also
+        # implies the classic mode).
+        return HTTP.Response(501, "Not Implemented")
     else
-        return HTTP.Response(
-            200,
-            """ {
-                "auth_flows": ["classic", "device"],
-                "device_token_refresh_url": "http://localhost:$PORT/auth/renew/token.toml/device/",
-                "device_authorization_endpoint": "http://localhost:$PORT/auth/device/code",
-                "device_token_endpoint": "http://localhost:$PORT/auth/token"
-            } """,
+        body = Dict(
+            "auth_flows" => ["classic", "device"],
+            "device_token_refresh_url" => "http://localhost:$PORT/auth/renew/token.toml/device/",
+            "device_authorization_endpoint" => "http://localhost:$PORT/auth/device/code",
+            "device_token_endpoint" => "http://localhost:$PORT/auth/token",
         )
+        # device_token_scope omitted in DEVICE_FLOW_NO_SCOPE_MODE
+        if MODE[] == DEVICE_FLOW_MODE
+            body["device_token_scope"] = "openid"
+        end
+        return HTTP.Response(200, JSON.json(body))
     end
 end
 
@@ -189,8 +199,7 @@ HTTP.register!(router, "POST", "/auth/device/code", auth_device_code)
 HTTP.register!(router, "GET", "/auth/device", auth_device)
 HTTP.register!(router, "POST", "/auth/token", auth_token)
 HTTP.register!(router, "GET", "/auth/renew/token.toml/device", renew_handler)
-HTTP.register!(router, "POST", "/set_mode/legacy", set_mode_legacy)
-HTTP.register!(router, "POST", "/set_mode/device", set_mode_device)
+HTTP.register!(router, "POST", "/set_mode/{mode}", set_mode)
 
 function run()
     println("starting server")


### PR DESCRIPTION
Fetches the `scope=` value of the device token from the configuration endpoint (`device_token_scope` property). If that is not set, we assume that `scope=` should not be passed (it's optional according to RFC 8628). X-ref: https://github.com/JuliaComputing/PkgAuthentication.jl/pull/42#discussion_r2136422530